### PR TITLE
CI: Add action variable on vitest job on deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
       - name: ⚡ Run vitest
         run: |
             skip_tests=""
-            if [[ -z "${{ env.skip_tests }}" ]]; then
+            if [[ -z "${{ env.SKIP_TESTS }}" ]]; then
               skip_tests="--passWithNoTests"
             fi
             npm run test -- --coverage "${skip_tests}" \


### PR DESCRIPTION
- Added Action variable on repository: `SKIP_TESTS`, to control the `vitest` job behaviour from the repository variable value.

**Note.-**  _When this action variable: `SKIP_TESTS` has any value it will skip `vitest` missing coverage error on the `deploy` workflow._
